### PR TITLE
商品一覧表示　実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    # @items = Item.includes(:user)
+    @items = Item.includes(:user).order("created_at DESC")
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,28 +123,27 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
-    <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+        <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+     <ul class='item-lists'>
+    <% @items.each do |item| %>
       <li class='list'>
         <%= link_to do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <%# <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
+          </div> %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,7 +152,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% end %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -121,9 +121,11 @@
   <%# /FURIMAの特徴 %>
 
   <%# 商品一覧 %>
+  <%# <% if user_signed_in? && @item == @item %> 
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
         <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+  <% if @item == @item %>
      <ul class='item-lists'>
     <% @items.each do |item| %>
       <li class='list'>
@@ -153,7 +155,7 @@
         <% end %>
       </li>
     <% end %>
-
+  <% else %>
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
@@ -172,6 +174,7 @@
           </div>
         </div>
         <% end %>
+  <% end %>
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -119,45 +119,38 @@
     </ul>
   </div>
   <%# /FURIMAの特徴 %>
-
-  <%# 商品一覧 %>
-  <%# <% if user_signed_in? && @item == @item %> 
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
         <%= link_to '新規投稿商品', "#", class: "subtitle" %>
-  <% if @item == @item %>
-     <ul class='item-lists'>
+    <% if @item == @item %>
+    <ul class='item-lists'>
     <% @items.each do |item| %>
       <li class='list'>
         <%= link_to do %>
-        <div class='item-img-content'>
-          <%= image_tag item.image, class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <%# <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div> %>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= item.name %>
-          </h3>
-          <div class='item-price'>
-            <span><%= item.price %>円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-img-content'>
+            <%= image_tag item.image, class: "item-img" %>
+                <%# 商品が売れていればsold outを表示しましょう %>
+                <%# <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div> %>
+                <%# //商品が売れていればsold outを表示しましょう %>
+          </div>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br>(税込み)</span>
+              <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
         <% end %>
       </li>
     <% end %>
-  <% else %>
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+    <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -174,13 +167,10 @@
           </div>
         </div>
         <% end %>
-  <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
     </ul>
+    <% end %>
   </div>
-  <%# /商品一覧 %>
 </div>
 <div class='purchase-btn'>
   <span class='purchase-btn-text'>出品する</span>


### PR DESCRIPTION
[What]
商品一覧表示の実装
sold outについては、商品購入機能実装後行うことにする。
[Why]
sold out以外の実装

キャプチャ動画はこちらになります。
ログアウトしているユーザーも一覧表示を確認できること
https://gyazo.com/5d998e43ef169f0e2c1667f9232c9b8d

出品した商品の一覧表示が確認できること
https://gyazo.com/164fd0230c35e032d9a4c1ffee651396

出品した商品が新規順に並んでいるかの確認
https://gyazo.com/267ddbab775cef504fa7f22d2e979e20